### PR TITLE
Black list "from" email addresses

### DIFF
--- a/sites/all/modules/unl/includes/unl.admin.inc
+++ b/sites/all/modules/unl/includes/unl.admin.inc
@@ -62,6 +62,15 @@ function unl_config($form, &$form_state) {
     '#access' => unl_user_is_administrator(),
   );
 
+  $form['root']['mail_from_blacklist'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Email From Blacklist (Global)',
+    '#description' => 'A comma separated list of email addresses that cannot be used as a "From" address.',
+    '#size' => 100,
+    '#default_value' => implode(',', unl_shared_variable_get('unl_mail_from_blacklist', array())),
+    '#access' => unl_user_is_administrator(),
+  );
+
   return $form;
 }
 
@@ -72,4 +81,5 @@ function unl_config_submit($form, &$form_state) {
     variable_set('unl_tidy', $form_state['values']['root']['unl_tidy']);
   }
   variable_set('unl_module_whitelist', $form_state['values']['root']['module_whitelist']);
+  variable_set('unl_mail_from_blacklist', explode(',', $form_state['values']['root']['mail_from_blacklist']));
 }

--- a/sites/all/modules/unl/unl.module
+++ b/sites/all/modules/unl/unl.module
@@ -1232,3 +1232,23 @@ function _unl_ssi_to_esi($url) {
   drupal_add_http_header('X-ESI', 'yes');
   return '<esi:include src="' . check_plain($url) . '"/>';
 }
+
+
+/**
+ * Implements hook_mail()
+ *
+ * Checks the "From" address of all outgoing messages against a blacklist.
+ * If a match is found, the email will not be sent.
+ */
+function unl_mail_alter(&$message) {
+  $address = trim($message['from']);
+  foreach (unl_shared_variable_get('unl_mail_from_blacklist', array()) as $blacklistedAddress) {
+    $blacklistedAddress = trim($blacklistedAddress);
+    if (strtolower($address) == strtolower($blacklistedAddress) ||
+        stripos($address, '<' . $blacklistedAddress . '>') !== FALSE) {
+      $message['send'] = FALSE;
+      watchdog('mail', 'An attempt as made to send an email with a blacklisted "From" address.', array(), WATCHDOG_ERROR);
+      drupal_set_message(t('You may not send email using that "From" address.'), 'error', FALSE);
+    }
+  }
+}


### PR DESCRIPTION
We need to add a black list of certain email address from being used in unlcms as the "From" address, including modules like webforms, etc.  This is to prevent someone from distributing to the UNL Today, and other listservs.
