### PR TITLE
Also look in DRUPAL_ROOT.'/.git/modules' for submodule .git dir

### DIFF
--- a/sites/all/modules/unl/unl.module
+++ b/sites/all/modules/unl/unl.module
@@ -1357,7 +1357,7 @@ function unl_system_info_git_submodule_version(&$info, $file, $type) {
     elseif (is_file($gitPath)) {
       $gitFile = file_get_contents($gitPath);
       $pieces = explode('gitdir: ', trim($gitFile));
-      $gitPath = dirname(__FILE__) . '/' . $pieces[1];
+      $gitPath = dirname($gitPath) . '/' . $pieces[1];
       if (is_dir($gitPath) && file_get_contents($gitPath . '/HEAD')) {
         break;
       }


### PR DESCRIPTION
Add on to e3c24ae

.git in the submodule dir might not be a dir and instead might be a file containing a gitdir path to the location of the submodule's .git dir
