### PR TITLE
[gh-806] Return from unl_og_membership_insert if not in OG user context

### DIFF
--- a/sites/all/modules/unl/unl.module
+++ b/sites/all/modules/unl/unl.module
@@ -31,9 +31,6 @@ function unl_og_membership_insert($og_membership) {
  * Removes Contributor role from user if they are no longer a member of any groups.
  */
 function unl_og_membership_delete($og_membership) {
-  if ($og_membership->group_type != 'user') {
-    return;
-  }
   $user = user_load($og_membership->etid);
   if (og_get_groups_by_user($user) == NULL && $role = user_role_load_by_name('Contributor')) {
     // Can't use user_multiple_role_edit because it calls user_save: https://drupal.org/node/1391474


### PR DESCRIPTION
Without this fix:

REFERRER    http://arts.unl.edu/node/add/course
MESSAGE PDOException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'uid' cannot be null: INSERT INTO {users_roles} (uid, rid) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1); Array ( [:db_insert_placeholder_0] => [:db_insert_placeholder_1] => 54 ) in unl_og_membership_insert() (line 21 of /var/www/htdocs/sites/all/modules/unl/unl.module).
