### PR TITLE
Add a user report

### DIFF
--- a/sites/all/modules/unl_cas/unl_cas.module
+++ b/sites/all/modules/unl_cas/unl_cas.module
@@ -258,15 +258,7 @@ function unl_cas_user_logout($account) {
   drupal_goto($cas->getLogoutUrl(url('<front>', array('absolute' => TRUE))));
 }
 
-/**
- * Generates and saves a user using info from LDAP or Directory
- */
-function unl_cas_import_user($username) {
-  $username = trim($username);
-  unl_load_zend_framework();
-  $user = array();
-  $result = array();
-
+function unl_cas_get_user_record($username) {
   // First, try getting the info from LDAP.
   try {
     $ldap = new Unl_Ldap(unl_cas_get_setting('ldap_uri'));
@@ -287,6 +279,18 @@ function unl_cas_import_user($username) {
       $result = json_decode($json, TRUE);
     }
   }
+  
+  return $result;
+}
+
+/**
+ * Generates and saves a user using info from LDAP or Directory
+ */
+function unl_cas_import_user($username) {
+  $username = trim($username);
+  unl_load_zend_framework();
+  $user = array();
+  $result = unl_cas_get_user_record($username);
 
   // Create the fields we will be using, and make an initial guess at the email address.
   $userData = array(

--- a/sites/all/modules/unl_multisite/user_report.php
+++ b/sites/all/modules/unl_multisite/user_report.php
@@ -54,7 +54,7 @@ foreach ($all_users as $uid=>$details) {
   
   $total_to_remove++;
   
-  echo 'uid "'. $uid . '" not found for:' . PHP_EOL;
+  echo '# uid "'. $uid . '" not found for:' . PHP_EOL;
   foreach ($details['sites'] as $uri) {
     echo "\t php sites/all/modules/drush/drush.php -l '$uri' user-remove-role 'Site Admin' --uid='$uid'" . PHP_EOL;
   }

--- a/sites/all/modules/unl_multisite/user_report.php
+++ b/sites/all/modules/unl_multisite/user_report.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Report all users that should be removed (no longer found in the directory)
+ * 
+ * Example Cron that will email daily:
+ * MAILTO="eric@unl.edu, mfairchild@unl.edu"
+ * @daily php user_report.php
+ * 
+ */
+
+if (PHP_SAPI != 'cli') {
+  echo 'This script must be run from the shell!';
+  exit;
+}
+
+chdir(dirname(__FILE__) . '/../../../..');
+define('DRUPAL_ROOT', getcwd());
+
+require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
+drupal_override_server_variables();
+drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
+require_once drupal_get_path('module', 'unl') . '/includes/common.php';
+require_once drupal_get_path('module', 'unl_multisite') . '/unl_site_creation.php';
+
+$map = unl_get_site_user_map('role', 'Site Admin', TRUE);
+
+unl_cas_get_adapter();
+
+$all_users = array();
+
+foreach ($map as $site) {
+  $users_not_found = array();
+  
+  foreach ($site['users'] as $uid=>$details) {
+    
+    if (!isset($all_users[$uid])) {
+      $record = unl_cas_get_user_record($uid);
+      
+      $all_users[$uid]['found'] = !(bool)empty($record);
+      $all_users[$uid]['sites'] = array();
+    }
+
+    if (!$all_users[$uid]['found']) {
+      $all_users[$uid]['sites'][] = $site['uri'];
+    }
+  }
+}
+
+$total_to_remove = 0;
+foreach ($all_users as $uid=>$details) {
+  if ($details['found']) {
+    continue;
+  }
+  
+  $total_to_remove++;
+  
+  echo 'uid "'. $uid . '" not found for:' . PHP_EOL;
+  foreach ($details['sites'] as $uri) {
+    echo "\t " . $uri . PHP_EOL;
+  }
+  
+  echo "run: drush-all-sites.php user-remove-role 'Site Admin' --uid='$uid'" . PHP_EOL;
+  echo PHP_EOL;
+}
+
+echo 'Total not found: ' . $total_to_remove . PHP_EOL;
+echo '(jellycup)' . PHP_EOL;

--- a/sites/all/modules/unl_multisite/user_report.php
+++ b/sites/all/modules/unl_multisite/user_report.php
@@ -56,10 +56,9 @@ foreach ($all_users as $uid=>$details) {
   
   echo 'uid "'. $uid . '" not found for:' . PHP_EOL;
   foreach ($details['sites'] as $uri) {
-    echo "\t " . $uri . PHP_EOL;
+    echo "\t php sites/all/modules/drush/drush.php -l '$uri' user-remove-role 'Site Admin' --uid='$uid'" . PHP_EOL;
   }
   
-  echo "run: drush-all-sites.php user-remove-role 'Site Admin' --uid='$uid'" . PHP_EOL;
   echo PHP_EOL;
 }
 


### PR DESCRIPTION
This report can be ran via cron and emailed as often as needed. Actually removing users will require manual intervention.

Example output:
```
uid "test" not found for:
         http://ucommfairchild.unl.edu/unlcms/newsite/
run: drush-all-sites.php user-remove-role 'Site Admin' --uid='test'

Total not found: 1
(jellycup)
```
