### PR TITLE
Smart cache

### DIFF
--- a/sites/all/modules/unl_cas/unl_cas.admin.inc
+++ b/sites/all/modules/unl_cas/unl_cas.admin.inc
@@ -181,7 +181,8 @@ function unl_cas_config($form, &$form_state) {
     $default = 1;
   }
   $form['ldap']['disable_smart_cache'] = array(
-    '#title' => 'Do not use the CAS smart cache (disable varnish for authenticated users that have no role)',
+    '#title' => 'Do not use CAS smart cache',
+    '#description' => 'Default to standard Drupal behavior of bypassing varnish for authenticated users.',
     '#type' => 'checkbox',
     '#default_value' => $default,
   );
@@ -202,8 +203,8 @@ function unl_cas_config_submit($form, &$form_state) {
   
   if ($form_state['values']['ldap']['disable_smart_cache']) {
     unl_cas_set_setting('disable_smart_cache', 'disable');
-  } else {
+  }
+  else {
     unl_cas_set_setting('disable_smart_cache', 'enable');
   }
-  
 }

--- a/sites/all/modules/unl_cas/unl_cas.admin.inc
+++ b/sites/all/modules/unl_cas/unl_cas.admin.inc
@@ -176,15 +176,11 @@ function unl_cas_config($form, &$form_state) {
     '#element_validate' => array('element_validate_number'),
   );
 
-  $default = 0;
-  if ('disable' === unl_cas_get_setting('disable_smart_cache')) {
-    $default = 1;
-  }
   $form['ldap']['disable_smart_cache'] = array(
     '#title' => 'Do not use CAS smart cache',
     '#description' => 'Default to standard Drupal behavior of bypassing varnish for authenticated users.',
     '#type' => 'checkbox',
-    '#default_value' => $default,
+    '#default_value' => (unl_cas_get_setting('disable_smart_cache') === 'disable' ? 1 : 0),
   );
 
   $form['submit'] = array(

--- a/sites/all/modules/unl_cas/unl_cas.admin.inc
+++ b/sites/all/modules/unl_cas/unl_cas.admin.inc
@@ -176,6 +176,16 @@ function unl_cas_config($form, &$form_state) {
     '#element_validate' => array('element_validate_number'),
   );
 
+  $default = 0;
+  if ('disable' === unl_cas_get_setting('disable_smart_cache')) {
+    $default = 1;
+  }
+  $form['ldap']['disable_smart_cache'] = array(
+    '#title' => 'Do not use the CAS smart cache (disable varnish for authenticated users that have no role)',
+    '#type' => 'checkbox',
+    '#default_value' => $default,
+  );
+
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => 'Update',
@@ -189,4 +199,11 @@ function unl_cas_config_submit($form, &$form_state) {
   unl_cas_set_setting('ldap_dn', $form_state['values']['ldap']['dn']);
   unl_cas_set_setting('ldap_password', $form_state['values']['ldap']['password']);
   unl_cas_set_setting('ldap_seconds', $form_state['values']['ldap']['seconds']);
+  
+  if ($form_state['values']['ldap']['disable_smart_cache']) {
+    unl_cas_set_setting('disable_smart_cache', 'disable');
+  } else {
+    unl_cas_set_setting('disable_smart_cache', 'enable');
+  }
+  
 }

--- a/sites/all/modules/unl_cas/unl_cas.module
+++ b/sites/all/modules/unl_cas/unl_cas.module
@@ -1,6 +1,7 @@
 <?php
 
 require_once drupal_get_path('module', 'unl') . '/includes/common.php';
+require_once __DIR__ . '/unl_cas_smart_cache.php';
 
 /**
  * Implements hook_enable().
@@ -124,6 +125,12 @@ function unl_cas_validate_ticket() {
 
   if ($auth) {
     $username = $cas->getUsername();
+    
+    //Do logic for checking if we need to force varnish for this user...
+    //This will set a cookie and redirect early if the user does not have an account... and won't make an account
+    unl_cas_smart_cache_run_for_user($username);
+    
+    //Now load LDAP
     $user = unl_cas_import_user($username);
     if (!$user) {
       drupal_set_message('An error occured importing the user.', 'error');

--- a/sites/all/modules/unl_cas/unl_cas_smart_cache.php
+++ b/sites/all/modules/unl_cas/unl_cas_smart_cache.php
@@ -33,9 +33,14 @@ function unl_cas_smart_cache_force_varnish_for_user($username) {
  * @return bool
  */
 function unl_cas_smart_cache_force_varnish_for_site() {
-  //TODO: check if the site is configured to not force varnish for users will no role.
+  if ('disable' === unl_cas_get_setting('disable_smart_cache')) {
+    return false;
+  }
   
-  //TODO: check if the site has the unl_access module turned on
+  if (module_exists('unl_access')) {
+    //Turn off smart cache because unl_access is enabled... We could improve this so only specific resources protected by unl_access are not cached.
+    return false;
+  }
   
   return true;
 }

--- a/sites/all/modules/unl_cas/unl_cas_smart_cache.php
+++ b/sites/all/modules/unl_cas/unl_cas_smart_cache.php
@@ -11,18 +11,17 @@ function unl_cas_smart_cache_force_varnish_for_user($username) {
   $account = user_load_by_name($username);
   
   if (!$account) {
-    //Couldn't find the user, so don't use smart cache.
+    // Couldn't find the user, so don't use smart cache.
     return false;
   }
 
   if (count($account->roles) > 1) {
-    //The user has more than one role, which means that they are more than just a guest
+    // The user has more than one role, which means that they are more than just a guest.
     return false;
   }
   
   //TODO: check if the user has any edit access to specific nodes (sounds like this might be possible)
-  
-  //else there is only one role left... make sure it is the authenticated user role
+
   return true;
 }
 
@@ -37,7 +36,7 @@ function unl_cas_smart_cache_force_varnish_for_site() {
   }
   
   if (module_exists('unl_access')) {
-    //Turn off smart cache because unl_access is enabled... We could improve this so only specific resources protected by unl_access are not cached.
+    // Turn off smart cache because unl_access is enabled... We could improve this so only specific resources protected by unl_access are not cached.
     return false;
   }
   
@@ -52,18 +51,19 @@ function unl_cas_smart_cache_force_varnish_for_site() {
 function unl_cas_smart_cache_run_for_user($username) {
   //do we really need to log the user in? Should we set a cookie to have VARNISH ignore the logged in state?
   if (unl_cas_smart_cache_force_varnish_for_user($username) && unl_cas_smart_cache_force_varnish_for_site()) {
-    //set a cookie to tell varnish to always run
+    // Set a cookie to tell varnish to always run
     setcookie('unlcms_force_varnish', 'true', 0, base_path());
 
-    //Redirect back
+    // Redirect back.
     $destination = drupal_get_destination();
     unset($_GET['destination']);
     drupal_goto($destination['destination']);
 
-    //don't proceed.
+    // Don't proceed.
     return;
-  } else {
-    //make sure the force_varnish cookie is turned off (delete the cookie
+  }
+  else {
+    // Make sure the force varnish cookie is turned off. (Delete the cookie.)
     setcookie('unlcms_force_varnish', 'false', time() - 3600, base_path());
   }
 }

--- a/sites/all/modules/unl_cas/unl_cas_smart_cache.php
+++ b/sites/all/modules/unl_cas/unl_cas_smart_cache.php
@@ -12,19 +12,18 @@ function unl_cas_smart_cache_force_varnish_for_user($username) {
   
   if (!$account) {
     //Couldn't find the user, so don't use smart cache.
-    return true;
+    return false;
   }
-  
-  $user_role = array_shift(array_values($account->roles));
-  if (count($account->roles) === 1 && 'authenticated user' === $user_role) {
+
+  if (count($account->roles) > 1) {
     //The user has more than one role, which means that they are more than just a guest
-    return true;
+    return false;
   }
   
   //TODO: check if the user has any edit access to specific nodes (sounds like this might be possible)
   
   //else there is only one role left... make sure it is the authenticated user role
-  return false;
+  return true;
 }
 
 /**

--- a/sites/all/modules/unl_cas/unl_cas_smart_cache.php
+++ b/sites/all/modules/unl_cas/unl_cas_smart_cache.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Determine if we should force varnish for a user
+ *
+ * @param $username
+ *
+ * @return bool
+ */
+function unl_cas_smart_cache_force_varnish_for_user($username) {
+  $account = user_load_by_name($username);
+  
+  if (!$account) {
+    //Couldn't find the user, so don't use smart cache.
+    return true;
+  }
+  
+  $user_role = array_shift(array_values($account->roles));
+  if (count($account->roles) === 1 && 'authenticated user' === $user_role) {
+    //The user has more than one role, which means that they are more than just a guest
+    return true;
+  }
+  
+  //TODO: check if the user has any edit access to specific nodes (sounds like this might be possible)
+  
+  //else there is only one role left... make sure it is the authenticated user role
+  return false;
+}
+
+/**
+ * Determine if we should use 'smart caching' for this site. In this case, smart caching is when we force varnish cache if the user has no role on the site.
+ *
+ * @return bool
+ */
+function unl_cas_smart_cache_force_varnish_for_site() {
+  //TODO: check if the site is configured to not force varnish for users will no role.
+  
+  //TODO: check if the site has the unl_access module turned on
+  
+  return true;
+}
+
+/**
+ * This will set the appropriate cookies and redirect if we need to. It should be ran right after CAS authentication and before a user account is created.
+ * 
+ * @param $username
+ */
+function unl_cas_smart_cache_run_for_user($username) {
+  //do we really need to log the user in? Should we set a cookie to have VARNISH ignore the logged in state?
+  if (unl_cas_smart_cache_force_varnish_for_user($username) && unl_cas_smart_cache_force_varnish_for_site()) {
+    //set a cookie to tell varnish to always run
+    setcookie('unlcms_force_varnish', 'true', 0, base_path());
+
+    //Redirect back
+    $destination = drupal_get_destination();
+    unset($_GET['destination']);
+    drupal_goto($destination['destination']);
+
+    //don't proceed.
+    return;
+  } else {
+    //make sure the force_varnish cookie is turned off (delete the cookie
+    setcookie('unlcms_force_varnish', 'false', time() - 3600, base_path());
+  }
+}


### PR DESCRIPTION
From #924 

This is more pseudo code than anything and would need to be heavily tested. The ideas is that right after authentication with CAS (and before LDAP lookup or account creation), check if the user even needs to be logged in. Then if the user does not need to be logged in, set a cookie for the site's domain+path that tells varnish to always cache (ignore the unl_sso cookie).

In other words:

If the user tries to log in (gateway auth via SSO) do the following:

perform the gateway auth
if user has role
log them in as usual
if user has no role (or is an 'authenticated user')
do not log them in and set a cookie unlcms_force_varnish, when varnish can then use to force varnish caching even if the SSO cookie is set.
There is also some checking to see if the unl_access module is enabled or if the smart caching was disabled for the site in the configuration. This can 'smart checking' can be vastly improved, but it gets the point across.

I'm not sure if this is the best approach, or if I covered all the necessary cases. I also don't know how to configure varnish to check for the new cookie, but I'm guessing its possible.

How to configure varnish:

I haven't actually tried this yet, but I think it should work.

After all of the other checks to see if content should be not cached, we could add a check like this

if (req.http.Cookie ~ "(^|;\s*)(unlcms_force_varnish=true)(;|$)"){
    //force varnish (bypass the unl_sso cookie), another alternative might be to unset the unl_sso cookie here
    return(hash);
}
Questions

if the unlcms_force_varnish is set, how can we still force a login if we need it? (maybe just unsetting the unl_sso cookie would be better)
Not quite sure how to still allow a gateway auth on pages restricted by unl_access. Perhaps have those pages serve a custom header (x-allow-gateway) and then modify the the above varnish config to NOT force a cache if that header is set?