### PR TITLE
Fix an issue where the base tag fix was not being applied if the current hash matched the link's hash

### DIFF
--- a/sites/all/modules/unl/unl.js
+++ b/sites/all/modules/unl/unl.js
@@ -37,22 +37,12 @@ Drupal.behaviors.unl = {
         return;
       }
 
-      var newHash = this.href.split('#')[1];
+      var newHash = '#'+this.href.split('#')[1];
+      
+      var newLocation = document.location.href.split('#')[0]+newHash;
 
-      if (document.location.hash == '#'+newHash) {
-          /**
-           * Fix for chrome.
-           * Avoid calling preventDefault() if there is no change in the hash
-           * For example, if you load the page with #maincontent the skiplink would no longer work because
-           * e.preventDefault() tells chrome to stop sending focus to #maincontent.
-           * ¯\_(ツ)_/¯
-           */
-          return;
-      }
-      
-      e.preventDefault();
-      
-      document.location.hash = newHash;
+      //Change the href of the event to the new location
+      e.originalEvent.currentTarget.href = newLocation;
     });
   }
 };


### PR DESCRIPTION
Instead of setting document.location.hash or using e.preventDefault(), just change the event's href. This will work with skipnav too.

Tested in Chrome.