### PR TITLE
Skip cbox elements (changes to an absolute URL breaks cbox)

### DIFF
--- a/sites/all/modules/unl/unl.js
+++ b/sites/all/modules/unl/unl.js
@@ -37,6 +37,11 @@ Drupal.behaviors.unl = {
         return;
       }
 
+      if ($(this).hasClass('cboxElement')) {
+          //Skip cbox elements (changes to an absolute URL breaks cbox)
+          return;
+      }
+
       var newHash = '#'+this.href.split('#')[1];
       
       var newLocation = document.location.href.split('#')[0]+newHash;


### PR DESCRIPTION
The latest fix breaks cbox links. For example, see http://unlcms.unl.edu/businessandfinance/student-accounts/undergraduate-tuition and click a link in the table. It appears the cbox does not like absolute links with fragments.

I think cbox will add the `cboxElement` class to any link that starts a cbox. So this solution should fix all cbox links. Note this will also break the link if someone right clicks and opens it in a new tab. =/

This is a hack for cbox, but there may be other similar situations. 

This is a good example of why I don't think we should have this js hack in the first place. The proper way to implement an in-page link when using the base tag is to include the relative URL (to the bast tag) with the #fragment.
